### PR TITLE
Add link to dominion paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ If you aren't able to access any paper on this list, please [try using Sci-Hub](
 - [Card Winning Stats on Dominion Server](http://councilroom.com/supply_win) (blogPost)
 - [Dominion Strategy Forum](http://forum.dominionstrategy.com/index.php) (forumPost)
 - [Clustering Player Strategies from Variable-Length Game Logs in Dominion](http://arxiv.org/abs/1811.11273) (journalArticle)
-- [Game Balancing in Dominion: An Approach to Identifying Problematic Game Elements]() (journalArticle)
+- [Game Balancing in Dominion: An Approach to Identifying Problematic Game Elements](https://web.archive.org/web/20220516093249/http://cs.gettysburg.edu/~tneller/games/aiagd/papers/EAAI-00039-FordC.pdf) (journalArticle)
 
 # Frameworks
 - [RLCard: A Toolkit for Reinforcement Learning in Card Games](http://arxiv.org/abs/1910.04376) (journalArticle)


### PR DESCRIPTION
Dominion paper link was present in the other file but not in the readme.